### PR TITLE
Add an interface that saves the peerstore to a db or to memory

### DIFF
--- a/src/metrics/prometheus/runner.go
+++ b/src/metrics/prometheus/runner.go
@@ -50,8 +50,8 @@ func (c *PrometheusRunner) Run(ctx context.Context) error {
 			nOfConnectedPeers := 0
 			geoDist := make(map[string]float64)
 
-			c.PeerStore.PeerStore.Range(func(k, val interface{}) bool {
-				peerData := val.(metrics.Peer)
+			c.PeerStore.PeerStore.Range(func(k string, val metrics.Peer) bool {
+				peerData := val
 
 				// TODO: Rethink this criteria
 				if peerData.ClientName != "Unknown" && peerData.ClientName != "" {

--- a/src/metrics/storage.go
+++ b/src/metrics/storage.go
@@ -1,0 +1,173 @@
+package metrics
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"reflect"
+	"runtime"
+	"sync"
+
+	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
+)
+
+// PeerStoreStorage provides the necessary functions
+// to interact with peers data.
+// It is either saved in a Db or in Memory.
+type PeerStoreStorage interface {
+	Store(key string, value Peer)
+	Load(key string) (value Peer, ok bool)
+	Delete(key string)
+	Range(f func(key string, value Peer) bool)
+}
+
+// PeerStoreDb save the peer's data in a persistant Db.
+type PeerStoreDb struct {
+	db *BoltDB
+}
+
+// PeerStoreMemory save the peer's data in RAM.
+// Unless exported, data is lost after execution.
+type PeerStoreMemory struct {
+	m *sync.Map
+}
+
+func (p *PeerStoreDb) Store(key string, value Peer) {
+	value_marshalled, err := json.Marshal(value)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	p.db.Store([]byte(key), value_marshalled)
+}
+
+func (p *PeerStoreDb) Load(key string) (value Peer, ok bool) {
+	value_marshalled, ok := p.db.Load([]byte(key))
+	if !ok {
+		return Peer{}, false
+	}
+
+	err := json.Unmarshal(value_marshalled, &value)
+	if err != nil {
+		log.Error(err)
+		return Peer{}, false
+	}
+	return value, true
+}
+
+func (p *PeerStoreDb) Delete(key string) {
+	p.db.Delete([]byte(key))
+}
+
+func (p *PeerStoreDb) Range(f func(key string, value Peer) bool) {
+	p.db.Range(func(key, value []byte) bool {
+		var value_unmarshalled Peer
+		err := json.Unmarshal(value, &value_unmarshalled)
+		if err != nil {
+			log.Error(err)
+			return false
+		}
+		ok := f(string(key), value_unmarshalled)
+		return ok
+	})
+}
+
+func (p *PeerStoreMemory) Store(key string, value Peer) {
+	p.m.Store(key, value)
+}
+
+func (p *PeerStoreMemory) Load(key string) (value Peer, ok bool) {
+	v, ok := p.m.Load(key)
+	if !ok {
+		return Peer{}, ok
+	}
+	value = v.(Peer)
+	return
+}
+
+func (p *PeerStoreMemory) Delete(key string) {
+	p.m.Delete(key)
+}
+
+func (p *PeerStoreMemory) Range(f func(key string, value Peer) bool) {
+	p.m.Range(func(key, value interface{}) bool {
+		ok := f(key.(string), value.(Peer))
+		return ok
+	})
+}
+
+// BoltDB implements basic operations to provide a key-value DB.
+type BoltDB struct {
+	db     *bolt.DB
+	bucket string
+}
+
+func OpenDB(path string, bucketName string, mode fs.FileMode, options *bolt.Options) (*BoltDB, error) {
+	boltDB, err := bolt.Open(path, mode, options)
+	if err != nil {
+		return &BoltDB{}, err
+	}
+
+	err = boltDB.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+		return err
+	})
+
+	db := &BoltDB{boltDB, bucketName}
+
+	return db, err
+}
+
+func (db *BoltDB) Close() {
+	db.db.Close()
+}
+
+func (db *BoltDB) Load(key []byte) (value []byte, ok bool) {
+	db.db.Update(func(t *bolt.Tx) error {
+		b := t.Bucket([]byte(db.bucket))
+		value = b.Get(key)
+		return nil
+	})
+
+	if value == nil {
+		ok = false
+	} else {
+		ok = true
+	}
+
+	return
+}
+
+func (db *BoltDB) Store(key, value []byte) {
+	db.db.Update(func(t *bolt.Tx) error {
+		b := t.Bucket([]byte(db.bucket))
+		err := b.Put(key, value)
+		return err
+	})
+}
+
+func (db *BoltDB) Delete(key []byte) {
+	db.db.Update(func(t *bolt.Tx) error {
+		b := t.Bucket([]byte(db.bucket))
+		err := b.Delete(key)
+		return err
+	})
+}
+
+func (db *BoltDB) Range(f func(key, value []byte) bool) {
+	db.db.View(func(t *bolt.Tx) error {
+		b := t.Bucket([]byte(db.bucket))
+		err := b.ForEach(func(k, v []byte) error {
+			if ok := f(k, v); !ok {
+				func_name := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+				err := fmt.Sprintf("Error while executing the function %v while on key %v", func_name, string(k))
+				return errors.New(err)
+			}
+			return nil
+		})
+
+		return err
+	})
+}

--- a/src/metrics/storage_test.go
+++ b/src/metrics/storage_test.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerStoreStorage(t *testing.T) {
+	var p PeerStoreStorage
+
+	db, err := OpenDB("test.db", "PeerStore", 0600, nil)
+	require.Nil(t, err)
+	defer db.Close()
+	defer os.Remove("test.db")
+
+	p = &PeerStoreDb{db}
+	testStorage(t, p)
+
+	var m sync.Map
+	p = &PeerStoreMemory{&m}
+	testStorage(t, p)
+}
+
+func testStorage(t *testing.T, p PeerStoreStorage) {
+	peer1 := Peer{
+		PeerId:     "1",
+		ClientName: "Client1",
+	}
+
+	peer2 := Peer{
+		PeerId:     "2",
+		ClientName: "Client2",
+	}
+
+	peer3 := Peer{
+		PeerId:     "3",
+		ClientName: "Client3",
+	}
+
+	p.Store("1", peer1)
+	p.Store("2", peer2)
+	p.Store("3", peer3)
+
+	peer_test, ok := p.Load("1")
+	require.True(t, ok)
+	require.Equal(t, "Client1", peer_test.ClientName)
+
+	peer_test, ok = p.Load("2")
+	require.True(t, ok)
+	require.Equal(t, "Client2", peer_test.ClientName)
+
+	var peerStoreTest []Peer
+
+	p.Range(func(key string, value Peer) bool {
+		peerStoreTest = append(peerStoreTest, value)
+		return true
+	})
+	require.Equal(t, 3, len(peerStoreTest))
+	require.Equal(t, peer1, peerStoreTest[0])
+	require.Equal(t, peer2, peerStoreTest[1])
+	require.Equal(t, peer3, peerStoreTest[2])
+
+	p.Delete("2")
+	_, ok = p.Load("2")
+	require.False(t, ok)
+}


### PR DESCRIPTION
After trying a lot of architectures for the interfaces, I found this one to be the most "elegant" and functional. 
There is a BoltDB struct that deals with the low level of Bolt, and can be reused for storing other parts than the peerstore. 
And there is two higher level structs that implements the PeerStoreStorage interface, one that deals with a DB and one with memory that just deals with storing and retrieving peers into a peerstore. 
I added the option to choose which storage medium we want when creating a new PeerStore with the function newPeerStore(), with the idea of having these arguments passed later on as cli flags. I don't know if you have a more efficient way to accomplish this functionality, which I assume is nice to have, but this is the easiest way I found to get it to work.