### PR TITLE
Peering metrics exporting routines generates concurrent map R/W operations

### DIFF
--- a/src/peering/prometheus_exporter.go
+++ b/src/peering/prometheus_exporter.go
@@ -2,6 +2,7 @@ package peering
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	promth "github.com/migalabs/armiarma/src/prometheus"
@@ -40,11 +41,11 @@ func (c *PeeringService) ServeMetrics(ctx context.Context) {
 
 				// generate the distribution
 				for key, value := range controlDist {
-					PrunedErrorDistribution.WithLabelValues(key).Set(float64(value))
+					PrunedErrorDistribution.WithLabelValues(key).Set(float64(atomic.LoadInt64(value)))
 				}
 				// generate the distribution
 				for key, value := range errorAttemptDist {
-					ErrorAttemptDistribution.WithLabelValues(key).Set(float64(value))
+					ErrorAttemptDistribution.WithLabelValues(key).Set(float64(atomic.LoadInt64(value)))
 				}
 
 				log.WithFields(log.Fields{

--- a/src/peering/strategy.go
+++ b/src/peering/strategy.go
@@ -23,8 +23,8 @@ type PeeringStrategy interface {
 	LastIterTime() float64
 	IterForcingNextConnTime() string
 	AttemptedPeersSinceLastIter() int64
-	ControlDistribution() map[string]int64
-	GetErrorAttemptDistribution() map[string]int64
+	ControlDistribution() map[string]*int64
+	GetErrorAttemptDistribution() map[string]*int64
 }
 
 // ConnectionAttemptStatus


### PR DESCRIPTION
The metrics exporting service of the Peering-Pruning module produces a FATAL error. 
The error:
```
fatal error: concurrent map iteration and map write

goroutine 140 [running]:
runtime.throw({0xdeca2c, 0xd762a0})
	/usr/local/go/src/runtime/panic.go:1198 +0x71 fp=0xc002c3acd8 sp=0xc002c3aca8 pc=0x437b11
runtime.mapiternext(0xc002c3ae60)
	/usr/local/go/src/runtime/map.go:858 +0x4eb fp=0xc002c3ad48 sp=0xc002c3acd8 pc=0x412bcb
github.com/migalabs/armiarma/src/peering.(*PeeringService).ServeMetrics.func1()
	/home/cortze/cortze/armiarma/src/peering/prometheus_exporter.go:46 +0x311 fp=0xc002c3afe0 sp=0xc002c3ad48 pc=0xbedd91
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc002c3afe8 sp=0xc002c3afe0 pc=0x467cc1
created by github.com/migalabs/armiarma/src/peering.(*PeeringService).ServeMetrics
	/home/cortze/cortze/armiarma/src/peering/prometheus_exporter.go:26 +0x28f
```  
It reports that two goroutines are simultaneously reading and writing on the same map, crashing the tool.

Proposed solution:

- [x] Add atomic iterations to any single map iteration
