### PR TITLE
Fix bug saving the TIME instead of the TIMESTAMP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 **/*.sh
 # docker-compose volumes
 app-data/*_db
+
+*.env

--- a/pkg/db/postgresql/active_peers_backup.go
+++ b/pkg/db/postgresql/active_peers_backup.go
@@ -26,10 +26,10 @@ func (c *DBClient) InitActivePeersTable() error {
 		`
 			CREATE TABLE IF NOT EXISTS active_peers(
 				id SERIAL,
-				timestamp TIME,
+				timestamp TIMESTAMP,
 				peers BIGINT[],
 
-				PRIMARY KEY(id)			
+				PRIMARY KEY(timestamp)			
 			);
 		`,
 	)

--- a/pkg/db/postgresql/server.go
+++ b/pkg/db/postgresql/server.go
@@ -112,6 +112,8 @@ func NewDBClient(
 	for i := 0; i < maxPersisters; i++ {
 		go dbClient.launchPersister()
 	}
+	// launch the daily backup heartbeat
+	go dbClient.dailyBackupheartbeat()
 	return dbClient, nil
 }
 
@@ -325,9 +327,6 @@ func (c *DBClient) launchPersister() {
 			}
 		}
 	}()
-
-	// launch the daily backup heartbeat
-	go c.dailyBackupheartbeat()
 }
 
 func (c *DBClient) dailyBackupheartbeat() {


### PR DESCRIPTION
# Description
This PR solves #54 

# Modifications 
- `timestamp` field in the `active_peers` table is changed to the `TIMESTAMP` type
- the `daily backup-exporter` has been moved from the DB persisted to avoid having multiple daily persisters