### PR TITLE
Add feature: RTT and IP distributions

### DIFF
--- a/pkg/crawler/metrics.go
+++ b/pkg/crawler/metrics.go
@@ -71,14 +71,14 @@ var (
 		Name:      "observed_rtt_distribution",
 		Help:      "Distribution of RTT between our tool and nodes in the network",
 	},
-		[]string{"rtt_range"},
+		[]string{"secs"},
 	)
 	IPDist = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: modName,
 		Name:      "observed_ip_distribution",
 		Help:      "Distribution of IPs hosting nodes in the network",
 	},
-		[]string{"repeated_ips"},
+		[]string{"numbernodes"},
 	)
 )
 

--- a/pkg/crawler/metrics.go
+++ b/pkg/crawler/metrics.go
@@ -62,9 +62,23 @@ var (
 	HostedPeers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: modName,
 		Name:      "hosted_peers_distribution",
-		Help:      "Distribution of IPs hosting the nodes in the network",
+		Help:      "Distribution of nodes that are hosted on non-residential networks",
 	},
 		[]string{"ip_host"},
+	)
+	RttDist = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: modName,
+		Name:      "observed_rtt_distribution",
+		Help:      "Distribution of RTT between our tool and nodes in the network",
+	},
+		[]string{"rtt_range"},
+	)
+	IPDist = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: modName,
+		Name:      "observed_ip_distribution",
+		Help:      "Distribution of IPs hosting nodes in the network",
+	},
+		[]string{"repeated_ips"},
 	)
 )
 
@@ -82,6 +96,8 @@ func (c *EthereumCrawler) GetMetrics() *metrics.MetricsModule {
 	metricsMod.AddIndvMetric(c.getPeersOs())
 	metricsMod.AddIndvMetric(c.getPeersArch())
 	metricsMod.AddIndvMetric(c.getHostedPeers())
+	metricsMod.AddIndvMetric(c.getRTTDist())
+	metricsMod.AddIndvMetric(c.getIPDist())
 
 	return metricsMod
 }
@@ -291,4 +307,57 @@ func (c *EthereumCrawler) getHostedPeers() *metrics.IndvMetrics {
 		return nil
 	}
 	return ipHosting
+}
+
+
+func (c *EthereumCrawler) getRTTDist() *metrics.IndvMetrics {
+	initFn := func() error {
+		prometheus.MustRegister(RttDist)
+		return nil
+	}
+	updateFn := func() (interface{}, error) {
+		summary, err := c.DB.GetRTTDistribution()
+		if err != nil {
+			return nil, err
+		}
+		for key, val := range summary {
+			RttDist.WithLabelValues(key).Set(float64(val.(int)))
+		}
+		return summary, nil
+	}
+	indvMetric, err := metrics.NewIndvMetrics(
+		"rtt_distribution",
+		initFn,
+		updateFn,
+	)
+	if err != nil {
+		return nil
+	}
+	return indvMetric
+}
+
+func (c *EthereumCrawler) getIPDist() *metrics.IndvMetrics {
+	initFn := func() error {
+		prometheus.MustRegister(IPDist)
+		return nil
+	}
+	updateFn := func() (interface{}, error) {
+		summary, err := c.DB.GetIPDistribution()
+		if err != nil {
+			return nil, err
+		}
+		for key, val := range summary {
+			IPDist.WithLabelValues(key).Set(float64(val.(int)))
+		}
+		return summary, nil
+	}
+	indvMetric, err := metrics.NewIndvMetrics(
+		"ip_distribution",
+		initFn,
+		updateFn,
+	)
+	if err != nil {
+		return nil
+	}
+	return indvMetric
 }

--- a/pkg/discovery/dv5/dv5_service.go
+++ b/pkg/discovery/dv5/dv5_service.go
@@ -134,8 +134,8 @@ func (d *Discovery5) nodeIterator() {
 		if d.Iterator.Next() {
 			// fill the given DiscoveredPeer interface with the next found peer
 			node := d.Iterator.Node()
-
 			log.WithFields(log.Fields{
+				"enr": node.String(),
 				"node_id": node.ID().String(),
 				"module":  "Discv5",
 			}).Debug("new ENR discovered")

--- a/pkg/gossipsub/topic_subscription.go
+++ b/pkg/gossipsub/topic_subscription.go
@@ -64,7 +64,7 @@ func (c *TopicSubscription) MessageReadingLoop(selfId peer.ID, dbClient database
 				// use the msg handler for that specific topic that we have
 				content, err := c.handlerFn(msg)
 				if err != nil {
-					log.Error(errors.Wrap(err, "unable to unwrap message on topic"+c.sub.Topic()))
+					log.Error(errors.Wrap(err, "unable to unwrap message on topic " + c.sub.Topic()))
 					continue
 				}
 				if !content.IsZero() && c.persistMsgs {

--- a/pkg/gossipsub/topic_subscription.go
+++ b/pkg/gossipsub/topic_subscription.go
@@ -64,7 +64,7 @@ func (c *TopicSubscription) MessageReadingLoop(selfId peer.ID, dbClient database
 				// use the msg handler for that specific topic that we have
 				content, err := c.handlerFn(msg)
 				if err != nil {
-					log.Error(errors.Wrap(err, "unable to unwrap message"))
+					log.Error(errors.Wrap(err, "unable to unwrap message on topic"+c.sub.Topic()))
 					continue
 				}
 				if !content.IsZero() && c.persistMsgs {


### PR DESCRIPTION
# Description
To maintain the backward compatibility of the crawler with previously available metrics, there were a few metrics not supported/exposed to Prometheus. 
This PR aims to fill those gaps, making the crawler 100% compatible with the [migalabs website](https://migalabs.es) 

# Tasks
- [x] Add support for the RTT distribution by ranges
- [x] Add support for the IP distribution.
