### PR TITLE
Swap DB call to get HostInfo to local peerstore calls

### DIFF
--- a/pkg/crawler/ethereum.go
+++ b/pkg/crawler/ethereum.go
@@ -194,7 +194,7 @@ func NewEthereumCrawler(mainCtx *cli.Context, conf config.EthereumCrawlerConfig)
 	}
 
 	// Build the event forwarder
-	eventHandler := events.NewForwarder(conf.SSEIP, conf.SSEPort, dbClient, ethMsgHandler)
+	eventHandler := events.NewForwarder(conf.SSEIP, conf.SSEPort, host, ethMsgHandler)
 
 	// generate the CrawlerBase
 	crawler := &EthereumCrawler{

--- a/pkg/hosts/host.go
+++ b/pkg/hosts/host.go
@@ -220,3 +220,33 @@ func (b *BasicLibp2pHost) RecIdentEvent(identEvent IdentificationEvent) {
 func (b *BasicLibp2pHost) IdentEventNotChannel() chan IdentificationEvent {
 	return b.identNotChannel
 }
+
+func (b *BasicLibp2pHost) GetHostInfo(peerID peer.ID) (models.HostInfo, error) {
+	var hostInfo models.HostInfo
+
+	// Connectivity of the node
+	hostInfo.MAddrs = b.host.Peerstore().Addrs(peerID)
+	addr := utils.GetPublicAddrsFromAddrArray(hostInfo.MAddrs)
+	hostInfo.IP = utils.ExtractIPFromMAddr(addr).String()
+	hostInfo.Port = utils.GetPortFromMaddrs(addr)
+
+	// Protocols
+	pv, err := b.host.Peerstore().Get(peerID, "ProtocolVersion")
+	if err == nil {
+		hostInfo.PeerInfo.ProtocolVersion = pv.(string)
+	}
+	prots, err := b.host.Peerstore().GetProtocols(peerID)
+	if err == nil {
+		supportedProtocols := make([]string, len(prots))
+		for i, prot := range prots {
+			supportedProtocols[i] = string(prot)
+		}
+		hostInfo.PeerInfo.Protocols = supportedProtocols
+	}
+	// Get user agent
+	ua, err := b.host.Peerstore().Get(peerID, "AgentVersion")
+	if err == nil {
+		hostInfo.PeerInfo.UserAgent = ua.(string)
+	}
+	return hostInfo, nil
+}


### PR DESCRIPTION
# Motivation
Making a DB query to fetch the peer info on each attestation message looks like a waste of time if that info is already accessible at the local host peerstore level.

_Related links:_
- #72 

# Description
This PR swaps fetching the whole set of HostIngo from a DB Call to a local-peerstore one

# Proof of Success
Working smoothly
```
eth_crawler-1  | time="2024-03-22T14:39:05Z" level=info msg="summary for discovery" attnets_distribution="map[-1:23 0:1252 2:17240 3:7 4:2 64:632]" node_per_fork_distribution="map[0x6a95a1a9:19156]"
eth_crawler-1  | time="2024-03-22T14:39:05Z" level=info msg="summary for host" connected_peers=267 suported protocols="map[/eth2/beacon_chain/req/metadata/2/ssz_snappy:1 /eth2/beacon_chain/req/ping/1/ssz_snappy:1 /eth2/beacon_chain/req/status/1/ssz_snappy:1 /floodsub/1.0.0:1 /ipfs/id/1.0.0:1 /ipfs/id/push/1.0.0:1 /ipfs/ping/1.0.0:1 /libp2p/circuit/relay/0.2.0/stop:1 /meshsub/1.0.0:1 /meshsub/1.1.0:1]"
eth_crawler-1  | time="2024-03-22T14:39:05Z" level=info msg="summary for gossipsub" peers_per_topic="map[/eth2/6a95a1a9/beacon_attestation_1/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_10/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_11/ssz_snappy:19 /eth2/6a95a1a9/beacon_attestation_12/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_13/ssz_snappy:12 /eth2/6a95a1a9/beacon_attestation_14/ssz_snappy:10 /eth2/6a95a1a9/beacon_attestation_15/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_16/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_17/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_18/ssz_snappy:10 /eth2/6a95a1a9/beacon_attestation_19/ssz_snappy:11 /eth2/6a95a1a9/beacon_attestation_2/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_20/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_21/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_22/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_23/ssz_snappy:18 /eth2/6a95a1a9/beacon_attestation_24/ssz_snappy:12 /eth2/6a95a1a9/beacon_attestation_25/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_26/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_27/ssz_snappy:9 /eth2/6a95a1a9/beacon_attestation_28/ssz_snappy:11 /eth2/6a95a1a9/beacon_attestation_29/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_3/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_30/ssz_snappy:15 /eth2/6a95a1a9/beacon_attestation_31/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_32/ssz_snappy:18 /eth2/6a95a1a9/beacon_attestation_33/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_34/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_35/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_36/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_37/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_38/ssz_snappy:15 /eth2/6a95a1a9/beacon_attestation_39/ssz_snappy:18 /eth2/6a95a1a9/beacon_attestation_4/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_40/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_41/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_42/ssz_snappy:19 /eth2/6a95a1a9/beacon_attestation_43/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_44/ssz_snappy:9 /eth2/6a95a1a9/beacon_attestation_45/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_46/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_47/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_48/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_49/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_5/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_50/ssz_snappy:15 /eth2/6a95a1a9/beacon_attestation_51/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_52/ssz_snappy:12 /eth2/6a95a1a9/beacon_attestation_53/ssz_snappy:10 /eth2/6a95a1a9/beacon_attestation_54/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_55/ssz_snappy:13 /eth2/6a95a1a9/beacon_attestation_56/ssz_snappy:12 /eth2/6a95a1a9/beacon_attestation_57/ssz_snappy:10 /eth2/6a95a1a9/beacon_attestation_58/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_59/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_6/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_60/ssz_snappy:14 /eth2/6a95a1a9/beacon_attestation_61/ssz_snappy:18 /eth2/6a95a1a9/beacon_attestation_62/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_63/ssz_snappy:16 /eth2/6a95a1a9/beacon_attestation_7/ssz_snappy:15 /eth2/6a95a1a9/beacon_attestation_8/ssz_snappy:17 /eth2/6a95a1a9/beacon_attestation_9/ssz_snappy:14 /eth2/6a95a1a9/beacon_block/ssz_snappy:207]"
eth_crawler-1  | time="2024-03-22T14:39:05Z" level=info msg="summary for local_node" local_head_slot="map[local_head_slot:8691193]"
```